### PR TITLE
add teams to checks

### DIFF
--- a/lib/puppet/provider/pingdom_check/check_base.rb
+++ b/lib/puppet/provider/pingdom_check/check_base.rb
@@ -142,6 +142,26 @@ Puppet::Type.type(:pingdom_check).provide(:check_base) do
         @property_hash[:tags] = (@property_hash[:tags] + value).join(',')
     end
 
+    def teams
+        # accepts list of ids, returns list of names
+        ids = @check.fetch('teams', nil).map { |i| i['id'].to_s }
+        team = api.select_teams(ids, search='id') if ids
+        if team.respond_to? :map
+            team.map { |u| u['name'] }
+        else
+            :absent
+        end
+    end
+
+    def teams=(value)
+        # accepts list of names, returns list of ids
+        teams = api.select_teams(value, search='name')
+        raise 'Unknown team in list' unless teams.size == value.size
+        ids = teams.map { |u| u['id'] }
+        newvalue = ids.join(',') if ids.respond_to? :join
+        @property_hash[:teamids] = newvalue
+    end
+
     #
     # utility methods
     #

--- a/lib/puppet/type/pingdom_check.rb
+++ b/lib/puppet/type/pingdom_check.rb
@@ -160,6 +160,19 @@ Puppet::Type.newtype(:pingdom_check) do
         end
     end
 
+    newproperty(:teams, :array_matching=>:all) do
+        desc 'Team names to contact [list of strings].'
+
+        def insync?(is)
+            case is
+                when :absent
+                    should.nil?
+                else
+                    should.nil? or is.sort == should.sort
+            end
+        end
+    end
+
     #
     # provider-specific properties
     #
@@ -268,5 +281,9 @@ Puppet::Type.newtype(:pingdom_check) do
     #
     autorequire(:pingdom_user) do
         self[:contacts]
+    end
+
+    autorequire(:pingdom_team) do
+        self[:teams]
     end
 end

--- a/lib/puppet_x/pingdom/client-2.1.rb
+++ b/lib/puppet_x/pingdom/client-2.1.rb
@@ -103,7 +103,9 @@ module PuppetX
             end
 
             def get_check_details(check)
-                response = @api.get "#{@@endpoint[:checks]}/#{check['id']}"
+                response = @api.get "#{@@endpoint[:checks]}/#{check['id']}", {
+                    :include_teams => true
+                }
                 response['check']
             end
 
@@ -137,6 +139,11 @@ module PuppetX
                     response = @api.get @@endpoint[:teams]
                     response['teams']
                 end
+            end
+
+            def select_teams(values, search='id')
+                # returns list of teams or nil
+                teams.select { |team| values.include? team[search] }
             end
 
             def create_team(params)

--- a/tests/create.pp
+++ b/tests/create.pp
@@ -63,7 +63,8 @@ pingdom_check { "http://${facts['fqdn']}/check":
     port             => 80,
     auth             => "admin:password",
     encryption       => false,
-    tags             => ['http']
+    tags             => ['http'],
+    teams            => ['SRE']
 }
 
 pingdom_check { "httpcustom://${facts['fqdn']}/status/pingdom.xml":


### PR DESCRIPTION
We implemented the Teams API, but failed to allow adding Teams to Checks. This fixes that.